### PR TITLE
Prevent Out of Memory with large streams

### DIFF
--- a/src/clj_kafka/core.clj
+++ b/src/clj_kafka/core.clj
@@ -39,15 +39,16 @@
    queue, and a function that inserts items into the queue.
 
    Source: http://clj-me.cgrand.net/2010/04/02/pipe-dreams-are-not-necessarily-made-of-promises/"
-  []
-  (let [q (LinkedBlockingQueue.)
-        EOQ (Object.)
-        NIL (Object.)
-        s (fn queue-seq []
-            (lazy-seq (let [x (.take q)]
-                        (when-not (= EOQ x)
-                          (cons (when-not (= NIL x) x)
-                                (queue-seq))))))]
-    [(s) (fn queue-put
-           ([] (.put q EOQ))
-           ([x] (.put q (or x NIL))))]))
+  ([] (pipe 100))
+  ([size]
+   (let [q (java.util.concurrent.LinkedBlockingQueue. size)
+         EOQ (Object.)
+         NIL (Object.)
+         s (fn queue-seq [] (lazy-seq
+                              (let [x (.take q)]
+                                (when-not (= EOQ x)
+                                  (cons (when-not (= NIL x) x)
+                                        (queue-seq))))))]
+     [(s) (fn queue-put
+            ([] (.put q EOQ))
+            ([x] (.put q (or x NIL))))])))


### PR DESCRIPTION
This version caps the queue and prevent OOM and obviously uses much less memory.

My app that use some like:

  (doseq [group (partition resolution (kafka/messages consumer topic))

Where resolution is a value of ~60000

Without this patch the memory usage was constantly around ~4gb

After dealing with OOMs and inspecting all vm snapshots I come that the problem was in the pipe, I checked your code then the linked article and was confirmed (in one comment) with the same solution.
