### PR TITLE
Do not use iterator-seq with KafkaStream

### DIFF
--- a/src/clj_kafka/consumer/zk.clj
+++ b/src/clj_kafka/consumer/zk.clj
@@ -28,6 +28,12 @@
   [^ConsumerConnector consumer]
   (.shutdown consumer))
 
+(defn- lazy-iterate
+  [it]
+  (lazy-seq
+   (when (.hasNext it)
+     (cons (.next it) (lazy-iterate it)))))
+
 (defn messages
   "Creates a sequence of KafkaMessage messages from the given topic. Consumes
    messages from a single stream."
@@ -35,4 +41,4 @@
   (let [[_topic [stream & _]]
         (first (.createMessageStreams consumer {topic (int 1)}))]
     (map to-clojure
-         (iterator-seq (.iterator ^KafkaStream stream)))))
+         (lazy-iterate (.iterator ^KafkaStream stream)))))

--- a/test/clj_kafka/test/consumer/zk.clj
+++ b/test/clj_kafka/test/consumer/zk.clj
@@ -34,9 +34,9 @@
       zk/shutdown
       (let [p (producer producer-config)]
         (send-messages p messages)
-        (zk/messages c "test")))))
+        (first (zk/messages c "test"))))))
 
-(given (first (send-and-receive [(test-message)]))
+(given (send-and-receive [(test-message)])
        (expect :topic "test"
                :offset 0
                :partition 0


### PR DESCRIPTION
Hello!

I found issue. Last message never consumes before consumer shutdown.

This is because IteratorSeq expects that hasNext is cheap and nonblocking op and calls it BEFORE create seq (https://github.com/clojure/clojure/blob/master/src/jvm/clojure/lang/IteratorSeq.java#L27). So, every call of rest (like in map) blocks thread.

Fortunately we do not need immutable representation of iterator (like iterator-seq), so it's easy to work with iterators without iterator-seq.
