### PR TITLE
Extend ToClojure protocol to nil

### DIFF
--- a/src/clj_kafka/core.clj
+++ b/src/clj_kafka/core.clj
@@ -26,6 +26,9 @@
   (to-clojure [x] "Converts type to Clojure structure"))
 
 (extend-protocol ToClojure
+  nil
+  (to-clojure [x] nil)
+
   MessageAndMetadata
   (to-clojure [x] (KafkaMessage. (.topic x) (.offset x) (.partition x) (.key x) (.message x)))
 


### PR DESCRIPTION
In some scenarios, some of the Kafka java data structures are nil/null.
E.g if the lead broker for a partition is not available, the returned PartitionMetaData will contain nil for it's leader which causes an IllegalArgumentException when to-clojure is applied.