### PR TITLE
Adds message-streams to high level consumer

### DIFF
--- a/test/clj_kafka/test/consumer/zk.clj
+++ b/test/clj_kafka/test/consumer/zk.clj
@@ -34,7 +34,7 @@
       zk/shutdown
       (let [p (producer producer-config)]
         (send-messages p messages)
-        (first (zk/messages c "test"))))))
+        (ffirst (zk/message-streams c "test"))))))
 
 (given (send-and-receive [(test-message)])
        (expect :topic "test"


### PR DESCRIPTION
Hopefully this is in line as discussed in #41. 

- message-streams returns a sequence of already transformed lazy sequences. 
  
  I couldn't think of practical use cases where just the stream is useful and so the common case
  is each sequence is immediately consumable by a Clojure consumer without having to map messages
- To get the old behavior of messages, one would simply take the first from message-streams
- messages serves as a more generalized way to transform a KafkaStream to a Clojure consumable lazy sequence

Please do let me know if message-streams should just return a sequence of KafkaStream, 
or be renamed, or anything else should be fixed up!