### PR TITLE
Update URL references to kafka incubator to use the 'real' kafka.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # clj-kafka
 
-Clojure library for [Kafka](http://incubator.apache.org/kafka/).
+Clojure library for [Kafka](https://kafka.apache.org).
 
 Current build status: [![Build Status](https://travis-ci.org/pingles/clj-kafka.png)](https://travis-ci.org/pingles/clj-kafka)
 

--- a/src/clj_kafka/consumer/zk.clj
+++ b/src/clj_kafka/consumer/zk.clj
@@ -6,7 +6,7 @@
 
 (defn consumer
   "Uses information in Zookeeper to connect to Kafka. More info on settings
-   is available here: http://incubator.apache.org/kafka/configuration.html
+   is available here: https://kafka.apache.org/08/configuration.html
 
    Recommended for using with with-resource:
    (with-resource [c (consumer m)]


### PR DESCRIPTION
Simple documentation update.