### PR TITLE
Allow supplying key and value decoders when creating message streams

### DIFF
--- a/src/clj_kafka/consumer/zk.clj
+++ b/src/clj_kafka/consumer/zk.clj
@@ -29,7 +29,7 @@
   (.shutdown consumer))
 
 (defn- lazy-iterate
-  [it]
+  [^java.util.Iterator it]
   (lazy-seq
    (when (.hasNext it)
      (cons (.next it) (lazy-iterate it)))))


### PR DESCRIPTION
Currently, only the simplest way of constructing message streams is exposed. This PR adds two optional keyword args to `clj-kafka.consumer.zk/messages`:

- `key-decoder`
- `value-decoder`

If at least one of these is non-nil, the message streams will be constructed using the supplied decoders.