### PR TITLE
expose all configured kafka streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,13 @@ The Zookeeper consumer uses broker information contained within Zookeeper to con
              "auto.offset.reset" "smallest"
              "auto.commit.enable" "false"})
 
-(with-resource [c (consumer config)]
-  shutdown
-  (take 2 (messages c "test")))
+(def c (consumer config))
+(def messages (first (message-seqs c "test")))
+(take 2 (messages c "test"))
+
+;; consume the messages - take is lazy!
+;; when done, do the following:
+(shutdown c)
 ```
 
 ## License

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
-(defproject clj-kafka/clj-kafka "0.2.8-0.8.1.1"
+(defproject clj-kafka/clj-kafka "0.2.8-0.8.1.1-concurrent-1"
   :min-lein-version "2.0.0"
-  :url "https://github.com/pingles/clj-kafka"
+  :url "https://github.com/sgerguri/clj-kafka"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.5.1"]
@@ -9,7 +9,7 @@
 
                  ;; kafka and its related deps
                  [org.apache.kafka/kafka_2.10 "0.8.1.1"]
-                 [org.apache.zookeeper/zookeeper "3.3.4"]
+                 [org.apache.zookeeper/zookeeper "3.4.6"]
                  [com.101tec/zkclient "0.4"]
                  [com.yammer.metrics/metrics-core "2.2.0"]
                  [org.scala-lang/scala-library "2.10.1"]

--- a/src/clj_kafka/consumer/zk.clj
+++ b/src/clj_kafka/consumer/zk.clj
@@ -8,11 +8,6 @@
   "Uses information in Zookeeper to connect to Kafka. More info on settings
    is available here: https://kafka.apache.org/08/configuration.html
 
-   Recommended for using with with-resource:
-   (with-resource [c (consumer m)]
-     shutdown
-     (take 5 (messages c \"test\")))
-
    Keys:
    zookeeper.connect             : host:port for Zookeeper. e.g: 127.0.0.1:2181
    group.id                      : consumer group. e.g. group1
@@ -34,12 +29,13 @@
    (when (.hasNext it)
      (cons (.next it) (lazy-iterate it)))))
 
-(defn messages
-  "Creates a sequence of KafkaMessage messages from the given topic. Consumes
-   messages from a single stream."
+(defn message-seqs
+  "Creates sequences of KafkaMessage messages from the given topic.
+  Consumes messages from multiple stream."
   [^ConsumerConnector consumer topic & {:keys [threads]
                                         :or   {threads 1}}]
-  (let [[_topic [stream & _]]
+  (let [[_topic streams]
         (first (.createMessageStreams consumer {topic (int threads)}))]
-    (map to-clojure
-         (lazy-iterate (.iterator ^KafkaStream stream)))))
+    (for [stream streams]
+      (map to-clojure
+           (lazy-iterate (.iterator ^KafkaStream stream))))))

--- a/test/clj_kafka/test/consumer/zk.clj
+++ b/test/clj_kafka/test/consumer/zk.clj
@@ -32,9 +32,10 @@
   (with-test-broker test-broker-config
     (with-resource [c (zk/consumer consumer-config)]
       zk/shutdown
-      (let [p (producer producer-config)]
+      (let [p (producer producer-config)
+            msg-seq (first (zk/message-seqs c "test"))]
         (send-messages p messages)
-        (first (zk/messages c "test"))))))
+        (first msg-seq)))))
 
 (given (send-and-receive [(test-message)])
        (expect :topic "test"


### PR DESCRIPTION
Currently, consumer.zk/messages allows multiple Kafka message streams to be configured but returns only 1 stream. This change drops this limitation, returning a lazy list of all the configured streams which can then be used to consume messages concurrently.