### PR TITLE
Dependency cleanup

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,16 +4,9 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.5.1"]
-                 [zookeeper-clj "0.9.3"]
                  [org.clojure/data.json "0.2.2"]
-
-                 ;; kafka and its related deps
                  [org.apache.kafka/kafka_2.10 "0.8.2.1"]
-                 [org.apache.zookeeper/zookeeper "3.3.4"]
-                 [com.101tec/zkclient "0.4"]
-                 [com.yammer.metrics/metrics-core "2.2.0"]
-                 [org.scala-lang/scala-library "2.10.1"]
-                 [net.sf.jopt-simple/jopt-simple "3.2"]]
+                 [zookeeper-clj "0.9.3"]]
   :exclusions [javax.mail/mail
                javax.jms/jms
                com.sun.jdmk/jmxtools
@@ -21,6 +14,5 @@
                jline/jline]
   :plugins [[lein-expectations "0.0.8"]]
   :profiles {:dev {:dependencies [[commons-io/commons-io "2.4"]
-                                  [expectations "1.4.45"]
-                                  [org.slf4j/slf4j-simple "1.6.4"]]}}
+                                  [expectations "1.4.45"]]}}
   :description "Clojure wrapper for Kafka's Java API")

--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
                  [org.clojure/data.json "0.2.2"]
 
                  ;; kafka and its related deps
-                 [org.apache.kafka/kafka_2.10 "0.8.1.1"]
+                 [org.apache.kafka/kafka_2.10 "0.8.2.1"]
                  [org.apache.zookeeper/zookeeper "3.3.4"]
                  [com.101tec/zkclient "0.4"]
                  [com.yammer.metrics/metrics-core "2.2.0"]

--- a/src/clj_kafka/core.clj
+++ b/src/clj_kafka/core.clj
@@ -43,7 +43,7 @@
 
   Broker
   (to-clojure [x]
-    {:connect (.getConnectionString x)
+    {:connect (.connectionString x)
      :host (.host x)
      :port (.port x)
      :broker-id (.id x)})

--- a/test/clj_kafka/test/utils.clj
+++ b/test/clj_kafka/test/utils.clj
@@ -3,7 +3,7 @@
     [kafka.admin AdminUtils]
     [kafka.server KafkaConfig KafkaServer]
     [java.net InetSocketAddress]
-    [org.apache.zookeeper.server ZooKeeperServer NIOServerCnxn$Factory]
+    [org.apache.zookeeper.server ZooKeeperServer NIOServerCnxnFactory]
     [org.apache.commons.io FileUtils]
     [org.I0Itec.zkclient ZkClient]
     [org.I0Itec.zkclient.serialize ZkSerializer]
@@ -39,7 +39,8 @@
   [{:keys [zookeeper-port]}]
   (let [tick-time 500
         zk (ZooKeeperServer. (file (tmp-dir "zookeeper-snapshot")) (file (tmp-dir "zookeeper-log")) tick-time)]
-    (doto (NIOServerCnxn$Factory. (InetSocketAddress. "127.0.0.1" zookeeper-port))
+    (doto (NIOServerCnxnFactory.)
+      (.configure (InetSocketAddress. "127.0.0.1" zookeeper-port) 10)
       (.startup zk))))
 
 (defn wait-until-initialised

--- a/test/clj_kafka/test/utils.clj
+++ b/test/clj_kafka/test/utils.clj
@@ -44,9 +44,9 @@
 
 (defn wait-until-initialised
   [^KafkaServer kafka-server topic]
-  (let [apis (.apis kafka-server)
-        cache (.metadataCache apis)]
-    (while (not (.containsTopicAndPartition cache topic 0))
+  (let [cache (.. kafka-server apis metadataCache)
+        topics (scala.collection.JavaConversions/asScalaSet #{topic})]
+    (while (< (.. cache (getTopicMetadata  topics) size) 1)
       (Thread/sleep 500))))
 
 (defn create-topic


### PR DESCRIPTION
Two main things:

1. Update kafka to 0.8.2.1 (latest)
  - two minor breaking changes fixed

2. Remove explicit dependencies that are already dependencies of Kafka (but with different versions). Let's give Kafka exactly the deps it requires, downstream users of this library can tweak if needed. Also, put `zookeeper-clj` last so it gets whatever `org.apache.zookeeper` version Kafka requires (not the other way around).

Admittedly, I don't know the history about the explicit deps, so I may be missing something. 
