### PR TITLE
Include :broker-id in each broker map returned by clj-kafka.zk/brokers

### DIFF
--- a/test/clj_kafka/test/zk.clj
+++ b/test/clj_kafka/test/zk.clj
@@ -21,7 +21,8 @@
        (expect :host "localhost"
                :jmx_port -1
                :port 9999
-               :version 1))
+               :version 1
+               (comp number? :broker-id) true))
 
 (given (with-test-broker config
                          (controller zk-connect))


### PR DESCRIPTION
I've changed `clj-kafka.zk/brokers` to also include the `:broker-id` in each broker map. I also took the liberty to refactor it a bit.
